### PR TITLE
Add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "jupyter_server>=2.0.0",
+    "psutil>=7.0.0",
     "pycurl>=7.43.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.26.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,117 @@
+import os
+import json
+import inspect
+import asyncio
+import secrets
+import shutil
+import time
+import psutil
+import pytest
+import logging
+
+from pathlib import Path
+from unittest import mock
+from functools import partial
+from tempfile import TemporaryDirectory
+from subprocess import Popen
+from tornado.httpclient import AsyncHTTPClient, HTTPClient
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(items):
+    """This function is automatically run by pytest passing all collected test
+    functions.
+
+    We use it to add asyncio marker to all async tests and assert we don't use
+    test functions that are async generators which wouldn't make sense.
+    """
+    for item in items:
+        if inspect.iscoroutinefunction(item.obj):
+            item.add_marker("asyncio")
+        assert not inspect.isasyncgenfunction(item.obj)
+
+
+@pytest.fixture(scope="session")
+def admin_token():
+    """Generate a token to use for admin requests"""
+    token = secrets.token_hex(16)
+    # jupyterhub subprocess loads this from the environment
+    with mock.patch.dict(os.environ, {"TEST_ADMIN_TOKEN": token}):
+        yield token
+
+
+@pytest.fixture(scope="session")
+def groups_token():
+    """Generate a token to use for groups exporter service requests"""
+    token = secrets.token_hex(16)
+    # jupyterhub subprocess loads this from the environment
+    with mock.patch.dict(os.environ, {"TEST_GROUPS_TOKEN": token}):
+        yield token
+
+
+@pytest.fixture(scope="session")
+def hub_url():
+    # hardcoded for now, but might want to override
+    return "http://127.0.0.1:8000"
+
+
+@pytest.fixture(scope="session")
+def hub(hub_url, request, admin_token):
+    """Start JupyterHub, set up to use our tokens"""
+    jupyterhub_config = Path.cwd().joinpath("tests/jupyterhub_config.py")
+    with TemporaryDirectory() as td:
+        shutil.copy(jupyterhub_config, Path(td).joinpath("jupyterhub_config.py"))
+        hub = Popen(["jupyterhub", "--debug"], cwd=td)
+
+        def cleanup():
+            if hub.poll() is None:
+                try:
+                    for p in psutil.Process(hub.pid).children():
+                        logger.info(f"terminating {p}")
+                        p.terminate()
+                except psutil.ProcessLookupError:
+                    pass
+            logger.info("terminating hub")
+            hub.terminate()
+
+        request.addfinalizer(cleanup)
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                HTTPClient().fetch(hub_url + "/hub/api")
+            except Exception as e:
+                logger.info(f"hub: {e}")
+                if hub.poll() is not None:
+                    raise RuntimeError("hub failed to start")
+                time.sleep(1)
+                continue
+            else:
+                break
+
+        yield hub
+
+
+async def api_request(hub_url, path, token=None, parse_json=True, **kwargs):
+    """Make an API request to the Hub, parsing JSON responses"""
+    hub_url = hub_url.rstrip("/")
+    headers = kwargs.setdefault("headers", {})
+    headers["Authorization"] = f"token {token}"
+
+    path = path.lstrip("/")
+    url = f"{hub_url}/hub/api/{path}"
+    logger.info(f"api_request: {url}, {kwargs}")
+    resp = await AsyncHTTPClient().fetch(url, **kwargs)
+    if not parse_json:
+        return resp
+    if resp.body:
+        return json.loads(resp.body.decode("utf8"))
+    else:
+        return None
+
+
+@pytest.fixture
+def admin_request(hub, hub_url, admin_token):
+    """make an API request to a path with an admin token"""
+    return partial(api_request, hub_url, token=admin_token)

--- a/tests/jupyterhub_config.py
+++ b/tests/jupyterhub_config.py
@@ -1,0 +1,60 @@
+import pathlib
+import secrets
+import sys
+import os
+
+c = get_config()  # noqa
+
+c.Authenticator.admin_users = {'admin'}
+c.JupyterHub.authenticator_class = "dummy"
+c.JupyterHub.spawner_class = "simple"
+
+c.JupyterHub.last_activity_interval = 3
+c.JupyterHub.ip = '127.0.0.1'
+c.JupyterHub.hub_ip = '127.0.0.1'
+c.JupyterHub.port = 8000
+c.JupyterHub.cleanup_proxy = True
+c.JupyterHub.cleanup_servers = True
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "pytest",
+        "scopes": [
+            "servers",
+            "admin:users",
+            "read:hub",
+        ],
+        "services": ["pytest"],
+    },
+    {
+        "name": "groups-exporter",
+        "scopes": [
+            "users",
+            "groups",
+        ],
+        "services": ["groups-exporter"],
+    },
+]
+
+service_port = 9090
+service_interval = 1  # minutes
+c.JupyterHub.services = [
+    {
+        "name": "pytest",
+        "api_token": os.environ["TEST_ADMIN_TOKEN"],
+    },
+    {
+        "name": "groups-exporter",
+        # "api_token": os.environ["TEST_GROUPS_TOKEN"],
+        "url": f"http://{c.JupyterHub.ip}:{service_port}",
+        "command": [
+            sys.executable,
+            "-m",
+            "jupyterhub_groups_exporter.groups_exporter",
+            "--port",
+            f"{service_port}",
+            "--interval",
+            f"{service_interval}",
+        ],
+    },
+]

--- a/tests/jupyterhub_config.py
+++ b/tests/jupyterhub_config.py
@@ -5,6 +5,14 @@ import os
 
 c = get_config()  # noqa
 
+n_users = 5
+c.Authenticator.allowed_users = {f"test-{i}" for i in range(n_users)}
+c.JupyterHub.load_groups = {
+    'group-0': {
+        'users': list(c.Authenticator.allowed_users),
+    },
+}
+
 c.Authenticator.admin_users = {'admin'}
 c.JupyterHub.authenticator_class = "dummy"
 c.JupyterHub.spawner_class = "simple"

--- a/tests/test_groups_exporter.py
+++ b/tests/test_groups_exporter.py
@@ -3,8 +3,20 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-async def test_hub_alive(hub_url, hub, admin_request):
+async def test_hub_alive(admin_request):
     """Test that the hub is alive and responding to requests."""
-    response = await admin_request("/info")
-    logger.info(f"test_hub_alive: {response}")
+    try:
+        response = await admin_request(path="hub/api/info")
+    except Exception as e:
+        raise RuntimeError("Hub is not alive")
     assert response["version"] is not None
+
+
+async def test_groups_exporter_alive(admin_request):
+    """Test that the hub is alive and responding to requests."""
+    try:
+        response = await admin_request(path="services/groups-exporter", parse_json=False)
+    except Exception as e:
+        logger.info(f"test_groups_exporter_alive: {e}")
+        raise RuntimeError("JupyterHub groups exporter service is not alive")
+    assert response is not None

--- a/tests/test_groups_exporter.py
+++ b/tests/test_groups_exporter.py
@@ -1,0 +1,10 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def test_hub_alive(hub_url, hub, admin_request):
+    """Test that the hub is alive and responding to requests."""
+    response = await admin_request("/info")
+    logger.info(f"test_hub_alive: {response}")
+    assert response["version"] is not None


### PR DESCRIPTION
Adds 2 initial tests:

1. Tests whether the hub api is alive at `/hub/api/info`
2. Tests whether the jupyter-groups-exporter is alive at `/services/groups-exporter`